### PR TITLE
Fix #17 by declaring custom query native

### DIFF
--- a/spring-data-jpa-postgresql/src/main/java/com/mkyong/repository/BookRepository.java
+++ b/spring-data-jpa-postgresql/src/main/java/com/mkyong/repository/BookRepository.java
@@ -14,7 +14,7 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     List<Book> findByTitle(String title);
 
     // Custom query
-    @Query("SELECT b FROM Book b WHERE b.publishDate > :date")
+    @Query(value = "SELECT b FROM Book b WHERE b.publishDate > :date", nativeQuery = true)
     List<Book> findByPublishedDateAfter(@Param("date") LocalDate date);
 
 }


### PR DESCRIPTION
Fix for `bean with name 'bookRepository' could not be created, query 'findByPublishedDateAfter()' could not be validated` Error, by declaring custom query native.